### PR TITLE
Fix gameplay component pause button

### DIFF
--- a/src/components/click-progression-game.js
+++ b/src/components/click-progression-game.js
@@ -1,5 +1,6 @@
 import { Screen } from "../../node_modules/genie/src/core/screen.js";
 import { gmi } from "../../node_modules/genie/src/core/gmi/gmi.js";
+import * as a11y from "../../node_modules/genie/src/core/accessibility/accessibility-layer.js";
 
 export class ClickProgressionGame extends Screen {
     constructor() {
@@ -23,6 +24,7 @@ export class ClickProgressionGame extends Screen {
         gmi.setGameData("characterSelected", this.transientData.characterSelected);
         console.log("Data saved to GMI:", gmi.getAllSettings().gameData); // eslint-disable-line no-console
 
+        a11y.resetElementsInDom(this);
     }
 
     render() {


### PR DESCRIPTION
Updates the gameplay component to reset the accessibility layer DOM. 

It feels like the ` a11y.resetElementsInDom` function should probably be called in Genie itself (probably in `navigation.js`) if possible. However, this should fix CGPROD-860 for the time being.