### PR TITLE
Sourcemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 | Version |                                          Change                                           |
 |---------|-------------------------------------------------------------------------------------------|
+| 0.0.9   | Prune scripts, add sourcemaps support to start:pack. |
 | 0.0.8   | Bump Genie core and include example stat calls. |
 | 0.0.7   | Bump Genie core. |
 | 0.0.6   | Bump Genie core. Updates for Babel 7 |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,13 +16,11 @@ New screens (including the gameplay component) should be created in the `compone
 
 You can preview your game by running a server using `npm start`. It can then be viewed in a browser at http://localhost:8080/ or at the local network address printed in the console. Changes to the source will trigger a rebuild and will refresh the page on all devices currently viewing the page. This command runs the code directly without webpacking it first.
 
-To webpack the code and then run a server, use `npm start:pack`. Please note to preview your game in IE11 you will need to webpack it first.
+To webpack the code and then run a server, use `npm start:pack`. This command will also add inline sourcemaps (when using Genie 1.0.12 or later). Please note to preview your game in IE11 you will need to webpack it first.
 
 The qaMode query string may be added to the end to view the game in QA Mode. This gives additional console output, and if you press "q", you can see the layout overlay. http://localhost:8000/?qaMode=true.
 
 To build your game using Webpack, use `npm run build`.
-
-`npm run build:watch` runs the compiler and creates a bundle. This means you can view index.html in a browser without having to run a webserver. Changes to the source will trigger a rebuild.
 
 ## ES6 Modules
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "childrens-games-genie-starter-pack",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "Children's BBC - Genie Starter Pack",
   "license": "UNLICENSED",
   "private": false,
@@ -23,9 +23,8 @@
   },
   "scripts": {
     "start": "ws --static.index node_modules/genie/dev/index.dev.html",
-    "start:pack": "webpack-dev-server --output-path=\"./output\" --config node_modules/genie/build-scripts/webpack.config.js",
+    "start:pack": "webpack-dev-server --output-path=\"./output\" --config node_modules/genie/build-scripts/webpack.config.js --env.development",
     "build": "webpack --config node_modules/genie/build-scripts/webpack.config.js",
-    "build:watch": "webpack --config node_modules/genie/build-scripts/webpack.config.js --watch",
     "eslint": "eslint . --ignore-pattern lodash --ignore-path .gitignore"
   }
 }


### PR DESCRIPTION
* Enables the sourcemap support in `npm run start:pack`
* Prunes old scripts