### PR TITLE
Add score to result menu on loss

### DIFF
--- a/src/components/click-progression-game.js
+++ b/src/components/click-progression-game.js
@@ -35,7 +35,7 @@ export class ClickProgressionGame extends Screen {
     gameLost() {
         gmi.sendStatsEvent("level", "complete", {metadata:`SCO=[0]~LVR=[LOSE]~SRC=[0]`});
         this.navigation.next({
-            results: "Game over - You lost!",
+            results: "You scored 0, game over - You lost!",
             characterSelected: this.transientData.characterSelected,
         });
     }


### PR DESCRIPTION
If there's no number in the score, there's no score reported in the stat. This adds a 0 into the score report if you lose the test genie game, so as to report a score stat.